### PR TITLE
Code Review: make ECCommandLine tests a bit more synchronous (#10469)

### DIFF
--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -15,27 +15,11 @@
 @implementation ExampleToolTests
 
 - (NSString*)runToolWithArguments:(NSArray*)arguments {
-	NSTask *task = [[NSTask alloc] init];
 	NSString* path = [[NSBundle bundleForClass:[self class]].bundlePath stringByDeletingLastPathComponent];
-	task.launchPath = [path stringByAppendingPathComponent:@"ECCommandLineExample"];
-	NSLog(@"launching %@", task.launchPath);
-	
-	if (arguments)
-		[task setArguments:arguments];
-	
-	NSPipe *pipe = [NSPipe pipe];
-	[task setStandardOutput: pipe];
 
-	NSPipe *errorPipe = [NSPipe pipe];
-	[task setStandardError: errorPipe];
-
-	NSFileHandle *file = [pipe fileHandleForReading];
-	NSFileHandle *errorFile = [errorPipe fileHandleForReading];
-	
-	[task launch];
-	
-	NSData *data = [file readDataToEndOfFile];
-	NSData* errorData = [errorFile readDataToEndOfFile];
+	int status;
+	NSData* errorData = nil;
+	NSData *data = [self runCommand:[path stringByAppendingPathComponent:@"ECCommandLineExample"] arguments:arguments status:&status error:&errorData];
 
 	NSString* output = [[NSString alloc] initWithData: data encoding:NSUTF8StringEncoding];
 	NSString* error = [[NSString alloc] initWithData: errorData encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Code review for make ECCommandLine tests a bit more synchronous (#10469):

> We have an occasional problem with output from the ECCommandLine unit tests messing up the output from the unit test reporting system, which causes our regexps to fail when scanning the test results.
> 
> This might be fixable by making the tests a bit more synchronous and ensuring that they wait properly for subprocesses to completely finish running.

Connect to BohemianCoding/Sketch#10469.
