### PR TITLE
Code Review: Give sketchtool the ability to tell Sketch to run a script (#12172)

### DIFF
--- a/Source/Generic/ECCommandLineEngine.m
+++ b/Source/Generic/ECCommandLineEngine.m
@@ -123,15 +123,17 @@ ECDefineDebugChannel(CommandLineEngineChannel);
 		optionPtr->flag = NULL;
 		optionPtr->val = option.shortOption;
 		NSString* shortChar = [NSString stringWithFormat:@"%c", option.shortOption];
-		[shortBuffer appendString:shortChar];
-		ECCommandLineOption* optionUsingChar = shortIndex[shortChar];
-		if (optionUsingChar)
-		{
-			NSLog(@"clash detected: %@ and %@ are both trying to use a short char of %@", option.name, optionUsingChar.name, shortChar);
-		}
-		else
-		{
-			shortIndex[shortChar] = option;
+		if ([shortChar length] == 1) {
+			[shortBuffer appendString:shortChar];
+			ECCommandLineOption* optionUsingChar = shortIndex[shortChar];
+			if (optionUsingChar)
+			{
+				NSLog(@"clash detected: %@ and %@ are both trying to use a short char of %@", option.name, optionUsingChar.name, shortChar);
+			}
+			else
+			{
+				shortIndex[shortChar] = option;
+			}
 		}
 		optionPtr++;
 	}];


### PR DESCRIPTION
Code review for Give sketchtool the ability to tell Sketch to run a script (#12172):

> Part of #10194.
> 
> Currently you have to use the `coscript` command line tool if you want to write a script to tell Sketch to run a plugin command.
> 
> That's a little awkward and complicated. What you actually run is a javascript that coscript executes. This javascript finds Sketch, launches it, and then tells it to run a plugin. By default the support that `coscript` offers doesn't allow you to specify the exact version of Sketch to run, and doesn't offer easy support for waiting until  Sketch exits (useful for long-running scripts), so you have to write that stuff yourself if needed, which is harder than it ought to be.
> 
> A simple solution to this is to implement a `run` command in `sketchtool`:
> 
> `sketchtool run </path/to/script/bundle> <command-id> --app=</path/to/sketch> --wait-for-exit --launch-new-instance`
> 
> The two main arguments are the bundle containing the command to run (if the bundle contains only one command, the command id can be omitted).
> 
> We want the command to allow specifying the exact path to the copy of Sketch that is going to be run.
> 
> However, since sketchtool normally lives *inside* Sketch, the default behaviour can just be to run the copy of Sketch containing `sketchtool`.
> 
> For things like performance testing, it's useful to know that you are running a clean copy of Sketch. Therefore it will be useful to support the option to launch a new instance even if one is already running*
> 
> For things like performance testing, it will also be useful to be able to wait for Sketch to exit before returning from the script command. Performance tests are likely to need to do things like opening a document, then performing one or more actions on it. It's quite tricky for a script like this to signal back to the original caller when it is done. The easiest signal there is probably just to exit Sketch. This will also ensure that the script doesn't sit round forever if Sketch crashes.
> 
> 
> (*however, there is a small issue surrounding this, relating to the DO port that Cocoascript uses, which will need fixing)
> 
> 
> (see #10720 for the original discussion around this issue)


Connect to BohemianCoding/Sketch#12172.