### PR TITLE
Code Review: Add context parameter to runPluginCommandWithIdentifier:fromBundleAtURL: (#12202)

### DIFF
--- a/Source/Generic/ECCommandLineEngine.m
+++ b/Source/Generic/ECCommandLineEngine.m
@@ -397,7 +397,13 @@ ECDefineDebugChannel(CommandLineEngineChannel);
 	NSString* string = [[NSString alloc] initWithFormat:format arguments:args];
 	va_end(args);
 
-	NSString* errorString = error ? [NSString stringWithFormat:@"(%@ %@:%ld)\n", error.localizedFailureReason, error.domain, error.code] : @"";
+
+
+	NSString* errorString = @"";
+	if (error) {
+		NSString* reason = error.localizedFailureReason;
+		errorString = reason? [NSString stringWithFormat:@"(%@ %@:%ld)\n", reason, error.domain, error.code] : [NSString stringWithFormat:@"(%@:%ld)\n", error.domain, error.code];
+	}
 	fprintf(stderr, "%s\n%s\n", [string UTF8String], [errorString UTF8String]);
 }
 


### PR DESCRIPTION
Code review for Add context parameter to runPluginCommandWithIdentifier:fromBundleAtURL: (#12202):

> The `runPluginCommandWithIdentifier:fromBundleAtURL:` method is used to allow external tools to trigger the running of plugins inside Sketch.
> 
> Currently there's no direct way for the external tool to supply any extra information to the plugin (the best way to do it is probably to set environment variables, and have the plugin read them, but that's complex and has various problems with it).
> 
> It might be an idea to extend this method to include a context dictionary. Keys and values supplied in this could then get merged in to the context that's eventually passed to the plugin command when it runs.
> 
> This may turn out to be necessary for the performance testing work, and sketchtool's support (#12172) could be updated to make use of it.


Connect to BohemianCoding/Sketch#12202.