### PR TITLE
Code Review: Ensure That Performance Tests Can Time Out (#12325)

### DIFF
--- a/Example/ECCommandLineExampleCommand.m
+++ b/Example/ECCommandLineExampleCommand.m
@@ -19,7 +19,7 @@
 	}
 	else
 	{
-		[engine outputError:nil format:@"We were expecting an argument."];
+		[engine outputErrorWithDomain:ECCommandLineDomain code:ECCommandLineResultMissingArguments info:@{} format:@"We were expecting an argument."];
 	}
 	return ECCommandLineResultOK;
 }

--- a/Source/Generic/ECCommandLineCommand.m
+++ b/Source/Generic/ECCommandLineCommand.m
@@ -276,7 +276,7 @@
 	}
 	else
 	{
-		[engine outputError:nil format:@"Missing arguments for command ‘%@’.\n", self.name];
+		[engine outputErrorWithDomain:ECCommandLineDomain code:ECCommandLineResultMissingArguments info:@{} format:@"Missing arguments for command ‘%@’.\n", self.name];
 		[engine outputFormat:@"Usage: %@\n", [self usageAs:self.name parentName:nil engine:engine]];
 	}
 
@@ -289,8 +289,7 @@
 			}
 			@catch (NSException *exception) {
 				commandResult = ECCommandLineResultImplementationReturnedError;
-				NSError* error = [NSError errorWithDomain:ECCommandLineDomain code:ECCommandLineResultImplementationReturnedError userInfo:@{NSLocalizedDescriptionKey : @"Command threw exception"}];
-				[engine outputError:error format:@"%@", exception];
+				[engine outputErrorWithDomain:ECCommandLineDomain code:ECCommandLineResultImplementationReturnedError info:@{} format:@"Command threw exception"];
 			}
 			
 			if (commandResult != ECCommandLineResultStayRunning)

--- a/Source/Generic/ECCommandLineEngine.h
+++ b/Source/Generic/ECCommandLineEngine.h
@@ -24,8 +24,8 @@
 - (void)showUsage;
 - (void)outputDescription:(NSString*)description;
 - (void)outputFormat:(NSString*)format, ... NS_FORMAT_FUNCTION(1,2);
-- (void)outputError:(NSError*)error description:(NSString*)description;
-- (void)outputError:(NSError*)error format:(NSString*)format, ... NS_FORMAT_FUNCTION(2,3);
+- (void)outputErrorWithDomain:(NSString*)domain code:(NSUInteger)code info:(NSDictionary*)info format:(NSString *)format, ... NS_FORMAT_FUNCTION(4,5);
+- (void)outputError:(NSError*)error;
 - (void)outputInfo:(id)info withKey:(NSString*)key;
 - (void)openInfoGroupWithKey:(NSString*)key;
 - (void)closeInfoGroup;

--- a/Source/Generic/ECCommandLineEngine.h
+++ b/Source/Generic/ECCommandLineEngine.h
@@ -24,7 +24,23 @@
 - (void)showUsage;
 - (void)outputDescription:(NSString*)description;
 - (void)outputFormat:(NSString*)format, ... NS_FORMAT_FUNCTION(1,2);
+
+/**
+ Makes a new NSError and then calls `outputError:`.
+ This can be used to wrap up an underlying error by passing it in with the info dictionary like so: @{ NSUnderlyingErrorKey : underlyingError }.
+ */
+
 - (void)outputErrorWithDomain:(NSString*)domain code:(NSUInteger)code info:(NSDictionary*)info format:(NSString *)format, ... NS_FORMAT_FUNCTION(4,5);
+
+/**
+ Output an error to stderr.
+ 
+ This can be a custom error we made, or something passed along to us by a system routine.
+ If there error contains a localized description or localized reason, then that is logged.
+ If it contains an underlying error, that's also logged.
+ In either case, the error domain and code are also logged.
+ */
+
 - (void)outputError:(NSError*)error;
 - (void)outputInfo:(id)info withKey:(NSString*)key;
 - (void)openInfoGroupWithKey:(NSString*)key;

--- a/Source/Generic/ECCommandLineEngine.m
+++ b/Source/Generic/ECCommandLineEngine.m
@@ -402,11 +402,15 @@ ECDefineDebugChannel(CommandLineEngineChannel);
 {
 	ECAssertNonNil(error);
 
-	NSString* reason = error.localizedFailureReason;
-	NSString* output = reason ? [NSString stringWithFormat:@"(%@ %@:%ld)\n", reason, error.domain, error.code] : [NSString stringWithFormat:@"(%@:%ld)\n", error.domain, error.code];
+	NSError* underlying = [error userInfo][NSUnderlyingErrorKey];
+	NSString* reason = error.localizedDescription ?: error.localizedFailureReason;
+	if (!reason && underlying) {
+		reason = underlying.localizedDescription ?: underlying.localizedFailureReason;
+	}
+
+	NSString* output = reason ? [NSString stringWithFormat:@"%@\n\n(%@:%ld)\n", reason, error.domain, error.code] : [NSString stringWithFormat:@"(%@:%ld)\n", error.domain, error.code];
 	fprintf(stderr, "%s\n", [output UTF8String]);
 
-	NSError* underlying = [error userInfo][NSUnderlyingErrorKey];
 	if (underlying) {
 		fprintf(stderr, "%s\n", [[underlying description] UTF8String]);
 	}

--- a/Source/Generic/ECCommandLineResult.h
+++ b/Source/Generic/ECCommandLineResult.h
@@ -21,4 +21,6 @@ typedef NS_ENUM(NSInteger, ECCommandLineResult)
 	ECCommandLineResultMissingArguments,
 	ECCommandLineResultImplementationReturnedError,
 	ECCommandLineResultMissingBundle,
+	ECCommandLineResultJSONConversionFailed,
+	ECCommandLineResultJSONOutputFailed,
 };


### PR DESCRIPTION
Code review for Ensure That Performance Tests Can Time Out (#12325):

> Part of #10194.
> 
> Currently if a performance test goes wrong, Sketch may well get left open, and sketchtool will sit around forever waiting for it to close.
> 
> We need to add a couple of levels of safety precaution to this to stop it from screwing up one of the build servers.
> 
> Firstly a `--timeout` option needs to be added to `sketchtool run` so that it'll give up waiting after a certain time.
> 
> Secondly the `bo performance run` command probably needs to spot that Sketch is already open and kill it.


Connect to BohemianCoding/Sketch#12325.