### PR TITLE
Code Review: Solve false Xcode 9.4 build warning (#18754)

### DIFF
--- a/ECCommandLine.xcodeproj/project.pbxproj
+++ b/ECCommandLine.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = "Elegant Chaos";
 				TargetAttributes = {
 					22381DE81A6C2FA9000AD60A = {

--- a/ECCommandLine.xcodeproj/xcshareddata/xcschemes/ECCommandLine.xcscheme
+++ b/ECCommandLine.xcodeproj/xcshareddata/xcschemes/ECCommandLine.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -82,7 +82,6 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -112,7 +111,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Code review for BohemianCoding/Sketch#18754 (“Solve false Xcode 9.4 build warning”):



Connect to BohemianCoding/Sketch#18754.