### PR TITLE
Code Review: Add option to hide commands and options (#23633)

### DIFF
--- a/Source/Generic/ECCommandLineCommand.h
+++ b/Source/Generic/ECCommandLineCommand.h
@@ -23,6 +23,7 @@ typedef void(^ArgumentBlock)(NSString* name, ECCommandLineArgumentMode mode, Uni
 @property (readonly, nonatomic) NSString* name;
 @property (readonly, nonatomic) NSArray* arguments;
 @property (readonly, nonatomic) ECCommandLineCommand* parentCommand;
+@property (readonly, nonatomic, getter=isHidden) BOOL hidden;
 
 + (ECCommandLineCommand*)commandWithName:(NSString*)name info:(NSDictionary*)info parentCommand:(ECCommandLineCommand*)parentCommand;
 

--- a/Source/Generic/ECCommandLineCommand.m
+++ b/Source/Generic/ECCommandLineCommand.m
@@ -84,6 +84,10 @@
 	return self.info[@"help"];
 }
 
+- (BOOL)isHidden {
+	return [self.info[@"hidden"] boolValue];
+}
+
 - (NSString*)summaryAs:(NSString*)name parentName:(NSString*)parentName
 {
 	NSString* fullName = parentName ? [NSString stringWithFormat:@"%@ %@", parentName, name] : name;
@@ -95,7 +99,9 @@
 		[result appendString:@"\n"];
 		for (ECCommandLineCommand* subcommand in sortedSubcommands)
 		{
-			[result appendFormat:@"%@", [subcommand summaryAs:subcommand.name parentName:fullName]];
+			if (!subcommand.isHidden) {
+				[result appendFormat:@"%@", [subcommand summaryAs:subcommand.name parentName:fullName]];
+			}
 		}
 		[result appendString:@"\n"];
 	}

--- a/Source/Generic/ECCommandLineEngine.m
+++ b/Source/Generic/ECCommandLineEngine.m
@@ -458,14 +458,16 @@ typedef NS_ENUM(NSUInteger, ECCommandLineOutputMode)
 	NSString* padding = [@"" stringByPaddingToLength:paddingLength withString:@" " startingAtIndex:0];
 	NSMutableString* string = [NSMutableString stringWithString:padding];
 	[self.options enumerateKeysAndObjectsUsingBlock:^(NSString* name, ECCommandLineOption* option, BOOL* stop) {
-		NSString* optionString = [NSString stringWithFormat:@" [%@ | %@]", option.longUsage, option.shortUsage];
-		if ([string length] + [optionString length] > 70)
-		{
-			[self outputFormat:@"%@\n", string];
-			[string setString:padding];
-		}
+		if (!option.isHidden) {
+			NSString* optionString = [NSString stringWithFormat:@" [%@ | %@]", option.longUsage, option.shortUsage];
+			if ([string length] + [optionString length] > 70)
+			{
+				[self outputFormat:@"%@\n", string];
+				[string setString:padding];
+			}
 
-		[string appendString:optionString];
+			[string appendString:optionString];
+		}
 	}];
 	[self outputFormat:@"%@\n", string];
 
@@ -473,7 +475,9 @@ typedef NS_ENUM(NSUInteger, ECCommandLineOutputMode)
 	NSArray* sortedCommands = [ECCommandLineEngine commandsInDisplayOrder:self.commands];
 	for (ECCommandLineCommand* command in sortedCommands)
 	{
-		[self outputFormat:@"%@", [command summaryAs:command.name parentName:nil]];
+		if (!command.isHidden) {
+			[self outputFormat:@"%@", [command summaryAs:command.name parentName:nil]];
+		}
 	};
 
 	[self outputFormat:@"\n\nSee ‘%@ help <command>’ for more information on a specific command.\n", self.name];

--- a/Source/Generic/ECCommandLineOption.h
+++ b/Source/Generic/ECCommandLineOption.h
@@ -20,6 +20,7 @@ typedef NS_ENUM(NSUInteger, ECCommandLineOptionMode)
 
 @property (readonly, nonatomic) NSString* name;
 @property (strong, nonatomic) id value;
+@property (readonly, nonatomic, getter=isHidden) BOOL hidden;
 
 + (ECCommandLineOption*)optionWithName:(NSString*)name info:(NSDictionary*)info;
 

--- a/Source/Generic/ECCommandLineOption.m
+++ b/Source/Generic/ECCommandLineOption.m
@@ -73,6 +73,10 @@
 	return result;
 }
 
+- (BOOL)isHidden {
+	return [self.info[@"hidden"] boolValue];
+}
+
 - (NSString*)longUsage
 {
 	NSString* result = [NSString stringWithFormat:@"--%@", self.name];


### PR DESCRIPTION
Resolves BohemianCoding/Sketch#23633 ("Export Cloud export bundle from sketchtool")

Add ability to hide commands and options from the usage help text. This lets us build private sketchtool commands.

Connect to BohemianCoding/Sketch#23633